### PR TITLE
chore: remove variable definition for claims

### DIFF
--- a/internal/http/middleware/jwt.go
+++ b/internal/http/middleware/jwt.go
@@ -25,9 +25,7 @@ func JWT(next echo.HandlerFunc) echo.HandlerFunc {
 			return echo.ErrUnauthorized
 		}
 
-		var claims jwt.RegisteredClaims
-
-		token, err := jwt.ParseWithClaims(auths[1], &claims, func(token *jwt.Token) (interface{}, error) {
+		token, err := jwt.ParseWithClaims(auths[1], new(jwt.RegisteredClaims), func(token *jwt.Token) (interface{}, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, ErrUnexpectedSingingMethod
 			}


### PR DESCRIPTION
Removing redundant variable definition for `claims`.